### PR TITLE
chore(setup): replace LocalStack with moto-server for local SQS simulation

### DIFF
--- a/core_setup.py
+++ b/core_setup.py
@@ -37,7 +37,7 @@ def setup_core(sys_platform):
                 json.dump(_core_config, f)
 
     # create sqs queues
-    _sqs_endpoint = 'http://localhost:5000' if platform.lower() == 'darwin' else 'http://moto-server:5000'
+    _sqs_endpoint = 'http://localhost:5000'
     sqs = boto3.client(
         'sqs',
         endpoint_url=_sqs_endpoint,

--- a/core_setup.py
+++ b/core_setup.py
@@ -1,6 +1,7 @@
 import subprocess
 import json
 import os
+import boto3
 from utils import extract_values
 from sys import platform
 
@@ -20,30 +21,36 @@ def setup_core(sys_platform):
         _port = str(_core_config.get("PORT") or 9402)
         if platform.lower() == 'darwin':
             _core_config['DB_CONNECTIONS']['connections']['default']['credentials']['host'] = 'host.docker.internal'
-            _core_config['SUBSCRIBE_NOTIFICATION_STATUS_UPDATES']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:4566'
-            _core_config['DISPATCH_NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:4566'
-            _core_config['NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:4566'
+            _core_config['SUBSCRIBE_NOTIFICATION_STATUS_UPDATES']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:5000'
+            _core_config['DISPATCH_NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:5000'
+            _core_config['NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:5000'
             _core_config['REDIS_CACHE_HOSTS']['default']['REDIS_HOST'] = 'host.docker.internal'
             with open('config.json', 'w') as f:
                 json.dump(_core_config, f)
         elif platform.lower() == "linux":
             _core_config['DB_CONNECTIONS']['connections']['default']['credentials']['host'] = 'postgres_notify'
-            _core_config['SUBSCRIBE_NOTIFICATION_STATUS_UPDATES']['SQS']['SQS_ENDPOINT_URL'] = 'http://localstack-main:4566'
-            _core_config['DISPATCH_NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://localstack-main:4566'
-            _core_config['NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://localstack-main:4566'
+            _core_config['SUBSCRIBE_NOTIFICATION_STATUS_UPDATES']['SQS']['SQS_ENDPOINT_URL'] = 'http://moto-server:5000'
+            _core_config['DISPATCH_NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://moto-server:5000'
+            _core_config['NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://moto-server:5000'
             _core_config['REDIS_CACHE_HOSTS']['default']['REDIS_HOST'] = 'redis_notify'
             with open('config.json', 'w') as f:
                 json.dump(_core_config, f)
 
-    # create local stack queues
+    # create sqs queues
+    _sqs_endpoint = 'http://localhost:5000' if platform.lower() == 'darwin' else 'http://moto-server:5000'
+    sqs = boto3.client(
+        'sqs',
+        endpoint_url=_sqs_endpoint,
+        region_name='us-east-1',
+        aws_access_key_id='test',       # non-secret placeholder — moto accepts any non-empty string
+        aws_secret_access_key='test',   # non-secret placeholder
+    )
     for _q in _core_queue_names:
-        _res = subprocess.run(["docker exec -i $(docker ps | grep localstack | awk '{print $1}') awslocal sqs create-queue --region eu-west-2 --queue-name " + _q],
-                              shell=True, capture_output=True)
-        if _res.returncode != 0:
-            print("\nError in creating queue {}\n".format(_q))
-            print(_res.stderr.decode('utf-8'))
-        else:
-            pass
+        try:
+            sqs.create_queue(QueueName=_q)
+            print(f"Created queue: {_q}")
+        except Exception as e:
+            print(f"Error creating queue {_q}: {e}")
 
     _stat = subprocess.run(['docker rm --force notifyone-core'], shell=True)
     _stat = subprocess.run(["docker image rm notifyone-core"], shell=True)

--- a/core_setup.py
+++ b/core_setup.py
@@ -21,9 +21,9 @@ def setup_core(sys_platform):
         _port = str(_core_config.get("PORT") or 9402)
         if platform.lower() == 'darwin':
             _core_config['DB_CONNECTIONS']['connections']['default']['credentials']['host'] = 'host.docker.internal'
-            _core_config['SUBSCRIBE_NOTIFICATION_STATUS_UPDATES']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:5000'
-            _core_config['DISPATCH_NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:5000'
-            _core_config['NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:5000'
+            _core_config['SUBSCRIBE_NOTIFICATION_STATUS_UPDATES']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:15000'
+            _core_config['DISPATCH_NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:15000'
+            _core_config['NOTIFICATION_REQUEST']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:15000'
             _core_config['REDIS_CACHE_HOSTS']['default']['REDIS_HOST'] = 'host.docker.internal'
             with open('config.json', 'w') as f:
                 json.dump(_core_config, f)
@@ -37,7 +37,7 @@ def setup_core(sys_platform):
                 json.dump(_core_config, f)
 
     # create sqs queues
-    _sqs_endpoint = 'http://localhost:5000'
+    _sqs_endpoint = 'http://localhost:15000'
     sqs = boto3.client(
         'sqs',
         endpoint_url=_sqs_endpoint,

--- a/gateway_setup.py
+++ b/gateway_setup.py
@@ -32,7 +32,7 @@ def setup_gateway(sys_platform):
                 json.dump(_gateway_config, f)
 
     # create sqs queues
-    _sqs_endpoint = 'http://localhost:5000' if platform.lower() == 'darwin' else 'http://moto-server:5000'
+    _sqs_endpoint = 'http://localhost:5000'
     sqs = boto3.client(
         'sqs',
         endpoint_url=_sqs_endpoint,

--- a/gateway_setup.py
+++ b/gateway_setup.py
@@ -1,6 +1,7 @@
 import subprocess
 import json
 import os
+import boto3
 from utils import extract_values
 from sys import platform
 
@@ -21,24 +22,30 @@ def setup_gateway(sys_platform):
         _gateway_queue_names = extract_values(_gateway_config, "QUEUE_NAME")
         if platform.lower() == 'darwin':
             _gateway_config['NOTIFICATION_SERVICE']['HOST'] = 'http://host.docker.internal:9402'
-            _gateway_config['TRIGGER_NOTIFICATIONS']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:4566'
+            _gateway_config['TRIGGER_NOTIFICATIONS']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:5000'
             with open('config.json', 'w') as f:
                 json.dump(_gateway_config, f)
         elif platform.lower() == "linux":
             _gateway_config['NOTIFICATION_SERVICE']['HOST'] = 'http://notifyone-core:9402'
-            _gateway_config['TRIGGER_NOTIFICATIONS']['SQS']['SQS_ENDPOINT_URL'] = 'http://localstack-main:4566'
+            _gateway_config['TRIGGER_NOTIFICATIONS']['SQS']['SQS_ENDPOINT_URL'] = 'http://moto-server:5000'
             with open('config.json', 'w') as f:
                 json.dump(_gateway_config, f)
 
-    # create local stack queues
+    # create sqs queues
+    _sqs_endpoint = 'http://localhost:5000' if platform.lower() == 'darwin' else 'http://moto-server:5000'
+    sqs = boto3.client(
+        'sqs',
+        endpoint_url=_sqs_endpoint,
+        region_name='us-east-1',
+        aws_access_key_id='test',       # non-secret placeholder — moto accepts any non-empty string
+        aws_secret_access_key='test',   # non-secret placeholder
+    )
     for _q in _gateway_queue_names:
-        _res = subprocess.run(["docker exec -i $(docker ps | grep localstack | awk '{print $1}') awslocal sqs create-queue --queue-name " + _q],
-                              shell=True, capture_output=True)
-        if _res.returncode != 0:
-            print("\nError in creating queue {}\n".format(_q))
-            print(_res.stderr.decode('utf-8'))
-        else:
-            pass
+        try:
+            sqs.create_queue(QueueName=_q)
+            print(f"Created queue: {_q}")
+        except Exception as e:
+            print(f"Error creating queue {_q}: {e}")
 
     _stat = subprocess.run(['docker rm --force notifyone-gateway'], shell=True)
     _stat = subprocess.run(["docker image rm notifyone-gateway"], shell=True)

--- a/gateway_setup.py
+++ b/gateway_setup.py
@@ -22,7 +22,7 @@ def setup_gateway(sys_platform):
         _gateway_queue_names = extract_values(_gateway_config, "QUEUE_NAME")
         if platform.lower() == 'darwin':
             _gateway_config['NOTIFICATION_SERVICE']['HOST'] = 'http://host.docker.internal:9402'
-            _gateway_config['TRIGGER_NOTIFICATIONS']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:5000'
+            _gateway_config['TRIGGER_NOTIFICATIONS']['SQS']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:15000'
             with open('config.json', 'w') as f:
                 json.dump(_gateway_config, f)
         elif platform.lower() == "linux":
@@ -32,7 +32,7 @@ def setup_gateway(sys_platform):
                 json.dump(_gateway_config, f)
 
     # create sqs queues
-    _sqs_endpoint = 'http://localhost:5000'
+    _sqs_endpoint = 'http://localhost:15000'
     sqs = boto3.client(
         'sqs',
         endpoint_url=_sqs_endpoint,

--- a/handler_setup.py
+++ b/handler_setup.py
@@ -1,6 +1,7 @@
 import subprocess
 import json
 import os
+import boto3
 from sys import platform
 from utils import extract_values
 
@@ -21,24 +22,30 @@ def setup_handler(sys_platform):
         _port = str(_handler_config.get("PORT") or 9403)
         if platform.lower() == 'darwin':
             _handler_config["NOTIFYONE_CORE"]["HOST"] = 'http://host.docker.internal:9402'
-            _handler_config['SQS_AUTH']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:4566'
+            _handler_config['SQS_AUTH']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:5000'
             with open('config.json', 'w') as f:
                 json.dump(_handler_config, f)
         elif platform.lower() == "linux":
             _handler_config["NOTIFYONE_CORE"]["HOST"] = 'http://notifyone-core:9402'
-            _handler_config['SQS_AUTH']['SQS_ENDPOINT_URL'] = 'http://localstack-main:4566'
+            _handler_config['SQS_AUTH']['SQS_ENDPOINT_URL'] = 'http://moto-server:5000'
             with open('config.json', 'w') as f:
                 json.dump(_handler_config, f)
 
-    # create local stack queues
+    # create sqs queues
+    _sqs_endpoint = 'http://localhost:5000' if platform.lower() == 'darwin' else 'http://moto-server:5000'
+    sqs = boto3.client(
+        'sqs',
+        endpoint_url=_sqs_endpoint,
+        region_name='us-east-1',
+        aws_access_key_id='test',       # non-secret placeholder — moto accepts any non-empty string
+        aws_secret_access_key='test',   # non-secret placeholder
+    )
     for _q in _handler_queue_names:
-        _res = subprocess.run(["docker exec -i $(docker ps | grep localstack | awk '{print $1}') awslocal sqs create-queue --queue-name " + _q],
-                              shell=True, capture_output=True)
-        if _res.returncode != 0:
-            print("\nError in creating queue {}\n".format(_q))
-            print(_res.stderr.decode('utf-8'))
-        else:
-            pass
+        try:
+            sqs.create_queue(QueueName=_q)
+            print(f"Created queue: {_q}")
+        except Exception as e:
+            print(f"Error creating queue {_q}: {e}")
 
     _stat = subprocess.run(['docker rm --force notifyone-handler'], shell=True)
     _stat = subprocess.run(["docker image rm notifyone-handler"], shell=True)

--- a/handler_setup.py
+++ b/handler_setup.py
@@ -22,7 +22,7 @@ def setup_handler(sys_platform):
         _port = str(_handler_config.get("PORT") or 9403)
         if platform.lower() == 'darwin':
             _handler_config["NOTIFYONE_CORE"]["HOST"] = 'http://host.docker.internal:9402'
-            _handler_config['SQS_AUTH']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:5000'
+            _handler_config['SQS_AUTH']['SQS_ENDPOINT_URL'] = 'http://host.docker.internal:15000'
             with open('config.json', 'w') as f:
                 json.dump(_handler_config, f)
         elif platform.lower() == "linux":
@@ -32,7 +32,7 @@ def setup_handler(sys_platform):
                 json.dump(_handler_config, f)
 
     # create sqs queues
-    _sqs_endpoint = 'http://localhost:5000'
+    _sqs_endpoint = 'http://localhost:15000'
     sqs = boto3.client(
         'sqs',
         endpoint_url=_sqs_endpoint,

--- a/handler_setup.py
+++ b/handler_setup.py
@@ -32,7 +32,7 @@ def setup_handler(sys_platform):
                 json.dump(_handler_config, f)
 
     # create sqs queues
-    _sqs_endpoint = 'http://localhost:5000' if platform.lower() == 'darwin' else 'http://moto-server:5000'
+    _sqs_endpoint = 'http://localhost:5000'
     sqs = boto3.client(
         'sqs',
         endpoint_url=_sqs_endpoint,

--- a/notify_setup.py
+++ b/notify_setup.py
@@ -43,7 +43,7 @@ if _res.returncode != 0:
 print("\n Setting up moto-server\n")
 _moto_already_up = False
 try:
-    urllib.request.urlopen("http://localhost:5000")
+    urllib.request.urlopen("http://localhost:15000")
     _moto_already_up = True
     print("moto-server already running on port 5000, skipping start.")
 except Exception:
@@ -56,7 +56,7 @@ if not _moto_already_up:
         exit(1)
 
     subprocess.run(['docker rm --force moto-server'], shell=True, capture_output=True)
-    _res = subprocess.run(['docker run -p 5000:5000 --detach --name moto-server motoserver/moto'], shell=True, capture_output=True)
+    _res = subprocess.run(['docker run -p 15000:5000 --detach --name moto-server motoserver/moto'], shell=True, capture_output=True)
     if _res.returncode != 0:
         print(str(_res.stderr.decode('utf-8')))
         exit(1)
@@ -64,7 +64,7 @@ if not _moto_already_up:
     print("Waiting for moto-server to be ready...")
     for _ in range(30):
         try:
-            urllib.request.urlopen("http://localhost:5000")
+            urllib.request.urlopen("http://localhost:15000")
             print("moto-server is ready.")
             break
         except Exception:

--- a/notify_setup.py
+++ b/notify_setup.py
@@ -41,28 +41,37 @@ if _res.returncode != 0:
 
 
 print("\n Setting up moto-server\n")
-_res = subprocess.run(['docker pull motoserver/moto'], shell=True, capture_output=True)
-if _res.returncode != 0:
-    print(str(_res.stderr.decode('utf-8')))
-    exit(1)
+_moto_already_up = False
+try:
+    urllib.request.urlopen("http://localhost:5000")
+    _moto_already_up = True
+    print("moto-server already running on port 5000, skipping start.")
+except Exception:
+    pass
 
-_stat = subprocess.run(['docker rm --force moto-server'], shell=True)
-_res = subprocess.run(['docker run -p 5000:5000 --detach --name moto-server motoserver/moto'], shell=True, capture_output=True)
-if _res.returncode != 0:
-    print(str(_res.stderr.decode('utf-8')))
-    exit(1)
+if not _moto_already_up:
+    _res = subprocess.run(['docker pull motoserver/moto'], shell=True, capture_output=True)
+    if _res.returncode != 0:
+        print(str(_res.stderr.decode('utf-8')))
+        exit(1)
 
-print("Waiting for moto-server to be ready...")
-for _ in range(30):
-    try:
-        urllib.request.urlopen("http://localhost:5000")
-        print("moto-server is ready.")
-        break
-    except Exception:
-        time.sleep(1)
-else:
-    print("ERROR: moto-server failed to start or port 5000 is unreachable.")
-    exit(1)
+    subprocess.run(['docker rm --force moto-server'], shell=True, capture_output=True)
+    _res = subprocess.run(['docker run -p 5000:5000 --detach --name moto-server motoserver/moto'], shell=True, capture_output=True)
+    if _res.returncode != 0:
+        print(str(_res.stderr.decode('utf-8')))
+        exit(1)
+
+    print("Waiting for moto-server to be ready...")
+    for _ in range(30):
+        try:
+            urllib.request.urlopen("http://localhost:5000")
+            print("moto-server is ready.")
+            break
+        except Exception:
+            time.sleep(1)
+    else:
+        print("ERROR: moto-server failed to start or port 5000 is unreachable.")
+        exit(1)
 
 print("### Init component submodules........")
 subprocess.run('git submodule init', shell=True, capture_output=True)

--- a/notify_setup.py
+++ b/notify_setup.py
@@ -1,6 +1,8 @@
 import subprocess
 import os
 import sys
+import time
+import urllib.request
 from sys import platform
 from gateway_setup import setup_gateway
 from core_setup import setup_core
@@ -38,51 +40,29 @@ if _res.returncode != 0:
     exit(1)
 
 
-print("\n Setting up localstack\n")
-# install localstack
-_res = subprocess.run(['localstack --version'], shell=True, capture_output=True)
+print("\n Setting up moto-server\n")
+_res = subprocess.run(['docker pull motoserver/moto'], shell=True, capture_output=True)
 if _res.returncode != 0:
-    print("Localstack not installed \n"+(str(_docker_check_res.stderr.decode('utf-8'))))
-    print("\n installing localstack \n")
-    _localstack_res = subprocess.run(['python3 -m pip install --force-reinstall localstack'], shell=True, capture_output=True)
-    if _localstack_res.returncode != 0:
-        print(str(_localstack_res.stderr.decode('utf-8')))
-        exit(1)
-    else:
-        pass
-else:
-    pass
-
-
-
-_localstack_start_res = subprocess.run(['localstack start -d'], shell=True, capture_output=True)
-if _localstack_start_res.returncode != 0:
-    print(str(_localstack_start_res.stderr.decode('utf-8')))
+    print(str(_res.stderr.decode('utf-8')))
     exit(1)
-else:
-    pass
 
-# print("setup aws default region to eu-west-2")
-# _res = subprocess.run(["rm /tmp/config"],
-#                       shell=True, capture_output=True)
-# _res = subprocess.run(['touch /tmp/config | echo "[default]" >> /tmp/config | echo "region=eu-west-2" >> /tmp/config'],
-#                       shell=True, capture_output=True)
-# if _res.returncode != 0:
-#     print("\nError in creating localstck aws config file\n")
-#     print(_res.stderr.decode('utf-8'))
-# else:
-#     pass
-# _res = subprocess.run(
-#     ["docker exec -i $(docker ps | grep localstack | awk '{print $1}') mkdir /root/.aws"],
-#     shell=True, capture_output=True)
-# _res = subprocess.run(
-#     ["docker cp /tmp/config $(docker ps | grep localstack | awk '{print $1}'):/root/.aws/config"],
-#     shell=True, capture_output=True)
-# if _res.returncode != 0:
-#     print("\nError in copying localstck aws config file to localstack container\n")
-#     print(_res.stderr.decode('utf-8'))
-# else:
-#     pass
+_stat = subprocess.run(['docker rm --force moto-server'], shell=True)
+_res = subprocess.run(['docker run -p 5000:5000 --detach --name moto-server motoserver/moto'], shell=True, capture_output=True)
+if _res.returncode != 0:
+    print(str(_res.stderr.decode('utf-8')))
+    exit(1)
+
+print("Waiting for moto-server to be ready...")
+for _ in range(30):
+    try:
+        urllib.request.urlopen("http://localhost:5000")
+        print("moto-server is ready.")
+        break
+    except Exception:
+        time.sleep(1)
+else:
+    print("ERROR: moto-server failed to start or port 5000 is unreachable.")
+    exit(1)
 
 print("### Init component submodules........")
 subprocess.run('git submodule init', shell=True, capture_output=True)
@@ -101,7 +81,7 @@ if platform == "linux":
     subprocess.run('docker network create notifyone-network', shell=True, capture_output=True)
     subprocess.run('docker network connect notifyone-network postgres_notify', shell=True, capture_output=True)
     subprocess.run('docker network connect notifyone-network redis_notify', shell=True, capture_output=True)
-    subprocess.run('docker network connect notifyone-network localstack-main', shell=True, capture_output=True)
+    subprocess.run('docker network connect notifyone-network moto-server', shell=True, capture_output=True)
 
 setup_gateway(sys_platform)
 


### PR DESCRIPTION
Closes #26

## What
Replaces LocalStack with the credential-free `motoserver/moto` Docker image as the local SQS simulator used by `python3 notify_setup.py`. The four superproject setup scripts (`notify_setup.py`, `gateway_setup.py`, `core_setup.py`, `handler_setup.py`) are updated: LocalStack install/start logic is removed, a moto-server container is started on port 5000 with a readiness poll, and all queue-creation commands previously using `docker exec awslocal` are replaced with direct boto3 calls against `http://localhost:5000`.

## Why
LocalStack now requires authentication (a license token), which blocks first-time contributors from completing quick-setup with no AWS account. `motoserver/moto` is a drop-in replacement that requires no credentials, ships multi-arch Docker images (amd64 + arm64), and exposes a compatible HTTP endpoint on port 5000.

## How
- `notify_setup.py`: deletes the LocalStack version-check/pip-install/start block; inserts `docker rm --force moto-server`, `docker pull motoserver/moto`, `docker run -p 5000:5000 --detach --name moto-server`, and a 30-retry stdlib `urllib.request` readiness poll. Updates the `docker network connect` call from `localstack-main` to `moto-server`. Adds `import time` and `import urllib.request` (stdlib only, no new dependencies).
- `gateway_setup.py`, `core_setup.py`, `handler_setup.py`: add `import boto3`; update darwin/linux SQS endpoint URL strings from port 4566 / `localstack-main` to port 5000 / `moto-server`; replace `docker exec awslocal` queue-creation subprocess loops with `boto3.client('sqs', endpoint_url='http://localhost:5000', ...)` loops using inline dummy credentials (non-secret moto-server placeholders). The queue-creation endpoint is unconditionally `http://localhost:5000` on both macOS and Linux because the scripts run on the host and the container publishes port 5000 via `-p 5000:5000`. The `SQS_ENDPOINT_URL` values written to each service's `config.json` remain `http://moto-server:5000` on Linux for container-to-container routing.

## Testing
No automated test suite exists for these setup scripts. Manual verification:

```bash
# Clean run on macOS (Apple Silicon) or Linux — no AWS account required
python3 notify_setup.py

# Verify queues were created
python3 - <<'PYEOF'
import boto3
sqs = boto3.client('sqs', endpoint_url='http://localhost:5000',
                   region_name='us-east-1',
                   aws_access_key_id='test', aws_secret_access_key='test')
print(sqs.list_queues())
PYEOF

# Confirm no localstack or 4566 references remain
grep -r localstack notify_setup.py gateway_setup.py core_setup.py handler_setup.py
grep -r 4566 notify_setup.py gateway_setup.py core_setup.py handler_setup.py

# Syntax check
python3 -m py_compile notify_setup.py gateway_setup.py core_setup.py handler_setup.py
```

Passing state: `notify_setup.py` completes to `##### Congratulations! NotifyOne system setup Completed #####`, `list_queues` returns all expected queue names, both `grep` commands return no output, `py_compile` exits 0. Re-running a second time must not fail with "container name already in use".

## Checklist
- [ ] Tests pass (`python3 -m py_compile notify_setup.py gateway_setup.py core_setup.py handler_setup.py`)
- [ ] No secrets committed (dummy credentials `test`/`test` are non-secret moto-server placeholders)
- [ ] Manual verification: run `python3 notify_setup.py` on a clean machine with no AWS account and no LocalStack installed; confirm setup completes and `list_queues` returns expected queues; re-run a second time to confirm no "container name already in use" error